### PR TITLE
Pass all cases for build

### DIFF
--- a/dashboard/models/build.js
+++ b/dashboard/models/build.js
@@ -18,6 +18,7 @@ const BuildSchema = new Schema({
     buildVersion: { type: String, default: "", trim: true, maxlength: 50 },
     buildIndex: { type: Number, default: 0 },
     isBaseline: { type: Boolean, default: false },
+    isAllPassed: { type: Boolean, default: false },
     caseCount: { type: Number, default: 0 },
     createdAt: { type: Date, default: Date.now },
     caseFailedCount: { type: Number, default: 0 },

--- a/dashboard/services/case-service.js
+++ b/dashboard/services/case-service.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const buildService = require("./build-service");
 const { CaseSchema } = require("../models/case");
 
 const Case = mongoose.model("Case", CaseSchema);
@@ -72,6 +73,43 @@ const cleanComprehensiveCaseResult = async cid => {
     }
 };
 
+
+const checkAndUpdateBuildResult = async cid => {
+    const allCases = await getAllCasesByCid(cid);
+
+    let [ passedCount, failedCount, undeterminedCount, passedByIgnoringRectanglesCount ] = [ 0, 0, 0, 0 ];
+    for (const testCase of allCases) {
+        switch (testCase.caseResult) {
+            case "undetermined":
+                undeterminedCount += 1;
+                break;
+            case "failed":
+                failedCount += 1;
+                break;
+            case "passed":
+                passedCount += 1;
+                break;
+        }
+
+        if (testCase.comprehensiveCaseResult === "passed") {
+            passedByIgnoringRectanglesCount += 1;
+        }
+    }
+
+    await buildService.updateTestCaseCount(allCases[0].pid, allCases[0].bid, {
+        passed: passedCount,
+        failed: failedCount,
+        undeterminedCount: undeterminedCount,
+        passedByIgnoringRectangles: passedByIgnoringRectanglesCount
+    });
+
+    const buildResult = undeterminedCount ? "undetermined"
+        : failedCount > passedByIgnoringRectanglesCount ? "failed" : "passed";
+
+    await buildService.updateBuildResult(allCases[0].bid, buildResult);
+};
+
+
 module.exports = {
     getBuildCases,
     getAllCasesByCid,
@@ -82,4 +120,5 @@ module.exports = {
     deleteByPid,
     getPlainTestCaseIgnoringRectangles,
     cleanComprehensiveCaseResult,
+    checkAndUpdateBuildResult,
 };

--- a/dashboard/views/build-standalone.pug
+++ b/dashboard/views/build-standalone.pug
@@ -32,6 +32,11 @@ block pageAction
                 form.mb-0(action="/build/debase/" + bid method="post")
                     button#rebase-button.btn.btn-sm.btn-outline-warning(disabled type="submit") Debase
 
+        .pl-2.pr-1
+            if !isAllPassed
+                form.mb-0(action="/build/pass/" + bid method="post")
+                    button#rebase-button.btn.btn-sm.btn-outline-success(type="submit") All Passed
+
 block main
     .container.table-container
         .pr-5.pl-5.pt-3


### PR DESCRIPTION
When uploading many cases for first time, it is difficult time consuming to mark each one as passed. 

This feature allows to pass build in one action.