### PR TITLE
allow ignore geometry starting from 0

### DIFF
--- a/dashboard/models/case.js
+++ b/dashboard/models/case.js
@@ -8,8 +8,8 @@ const Schema = mongoose.Schema;
  * Build Schema
  */
 const RectangleSchema = new Schema({
-    x: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
-    y: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
+    x: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
+    y: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
     width: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
     height: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] }
 });

--- a/dashboard/models/ignoring.js
+++ b/dashboard/models/ignoring.js
@@ -7,8 +7,8 @@ const Schema = mongoose.Schema;
  * Build Schema
  */
 const RectangleSchema = new Schema({
-    x: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
-    y: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
+    x: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
+    y: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
     width: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
     height: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] }
 });

--- a/engine/models/case.js
+++ b/engine/models/case.js
@@ -9,8 +9,8 @@ const Schema = mongoose.Schema;
  * Build Schema
  */
 const RectangleSchema = new Schema({
-    x: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
-    y: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
+    x: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
+    y: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
     width: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
     height: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] }
 });

--- a/engine/models/ignoring.js
+++ b/engine/models/ignoring.js
@@ -7,8 +7,8 @@ const Schema = mongoose.Schema;
  * Build Schema
  */
 const RectangleSchema = new Schema({
-    x: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
-    y: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
+    x: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
+    y: { type: Number, default: null, min: [0, 'Must be 0 or greater, got {VALUE}'] },
     width: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] },
     height: { type: Number, default: null, min: [1, 'Must be greater than 0, got {VALUE}'] }
 });


### PR DESCRIPTION
I ran into some issues attempting to ignore the entire top portion of the screen (e.g. to ignore the time / battery indicator / etc... on mobile screenshots). I *think* it should be OK to ignore from 0,0 so long as the width / height is >= 1.