### PR TITLE
Preserve ignoring on rebase

### DIFF
--- a/dashboard/models/project.js
+++ b/dashboard/models/project.js
@@ -20,6 +20,7 @@ const ProjectSchema = new Schema({
     projectDetectAntialiasing: { type: Boolean, default: true },
     projectIgnoringCluster: { type: Boolean, default: true },
     projectIgnoringClusterSize: { type: Number, default: 50, min: 1, max: 5000 },
+    preserveIgnoringOnRebase: { type: Boolean, default: false },
     createdAt: { type: Date, default: Date.now },
 });
 
@@ -75,6 +76,11 @@ ProjectSchema.methods = {
 
     updateProjectIgnoringClusterSize: function (projectIgnoringClusterSize) {
         this.projectIgnoringClusterSize = projectIgnoringClusterSize;
+        return this.save();
+    },
+
+    updatePreserveIgnoringOnRebase: function (projectPreserveIgnoringOnRebase) {
+        this.preserveIgnoringOnRebase = projectPreserveIgnoringOnRebase;
         return this.save();
     }
 };

--- a/dashboard/routes/admin.js
+++ b/dashboard/routes/admin.js
@@ -210,6 +210,12 @@ router.post("/project/config/:pid", authenticateJWT, function(req, res, next) {
                 console.error(`projectClusterSize ${req.body.projectIgnoringClusterSize} from PID ${req.params.pid} is not acceptable`);
             }
 
+            if (req.body.preserveIgnoringOnRebase === "on") {
+                await projectService.updateEnablePreserveIgnoringOnRebase(project.pid, true);
+            } else {
+                await projectService.updateEnablePreserveIgnoringOnRebase(project.pid, false);
+            }
+
             res.redirect(`/project/${project.pid}/page/1`);
 
         } catch (error) {

--- a/dashboard/routes/build.js
+++ b/dashboard/routes/build.js
@@ -65,7 +65,10 @@ router.post("/rebase/:bid", authenticateJWT, function(req, res, next) {
         try {
             const build = await buildService.getBuildByBid(req.params.bid);
             const project = await projectService.getProjectByPid(build.pid);
-            await ignoringService.cleanProjectIgnoring(build.pid);
+
+            if (!project.preserveIgnoringOnRebase) {
+                await ignoringService.cleanProjectIgnoring(build.pid);
+            }
 
             await buildService.rebase(project.projectName, req.params.bid);
             res.redirect(`/build/${req.params.bid}`);
@@ -82,7 +85,10 @@ router.post("/debase/:bid", authenticateJWT, function(req, res, next) {
         try {
             const build = await buildService.getBuildByBid(req.params.bid);
             const project = await projectService.getProjectByPid(build.pid);
-            await ignoringService.cleanProjectIgnoring(build.pid);
+
+            if (!project.preserveIgnoringOnRebase) {
+                await ignoringService.cleanProjectIgnoring(build.pid);
+            }
 
             await buildService.debase(project, build);
             res.redirect(`/build/${req.params.bid}`);

--- a/dashboard/routes/project.js
+++ b/dashboard/routes/project.js
@@ -88,6 +88,7 @@ router.get("/:pid/page/:page", authenticateJWT, function(req, res, next) {
                 projectDetectAntialiasing: project.projectDetectAntialiasing,
                 projectIgnoringCluster: project.projectIgnoringCluster,
                 projectIgnoringClusterSize: project.projectIgnoringClusterSize,
+                preserveIgnoringOnRebase: project.preserveIgnoringOnRebase,
             });
         } catch (error) {
             console.error(error);

--- a/dashboard/services/project-service.js
+++ b/dashboard/services/project-service.js
@@ -59,6 +59,11 @@ const updateProjectIgnoringClusterSize = async (pid, projectIgnoringClusterSize)
     await project.updateProjectIgnoringClusterSize(projectIgnoringClusterSize);
 };
 
+const updateEnablePreserveIgnoringOnRebase = async (pid, enablePreserveIgnoringOnRebase) => {
+    const project = await getProjectByPid(pid);
+    await project.updatePreserveIgnoringOnRebase(enablePreserveIgnoringOnRebase);
+};
+
 module.exports = {
     createProject,
     getAllProjects,
@@ -70,5 +75,6 @@ module.exports = {
     updateProjectColorThreshold,
     updateProjectDetectAntialiasing,
     updateEnableProjectIgnoringCluster,
-    updateProjectIgnoringClusterSize
+    updateProjectIgnoringClusterSize,
+    updateEnablePreserveIgnoringOnRebase
 };

--- a/dashboard/views/project.pug
+++ b/dashboard/views/project.pug
@@ -55,6 +55,12 @@ block projectAction
                               option(selected)= val
                             else
                               option= val
+                      li.list-group-item.config-item.d-flex.justify-content-between.flex-row
+                        .font-weight-light.text-white Preserve Ignoring on Rebase
+                        if preserveIgnoringOnRebase
+                          input#preserveIgnoringOnRebase.form-check-input(type='checkbox' name='preserveIgnoringOnRebase' style='position: unset' checked)
+                        else
+                          input#preserveIgnoringOnRebase.form-check-input(type='checkbox' name='preserveIgnoringOnRebase' style='position: unset')
                     .modal-footer
                       button.btn.btn-outline-info(type='button' data-dismiss='modal') Cancel
                       button.btn.btn-outline-success(type='submit') Update

--- a/engine/models/project.js
+++ b/engine/models/project.js
@@ -20,6 +20,7 @@ const ProjectSchema = new Schema({
     projectDetectAntialiasing: { type: Boolean, default: true },
     projectIgnoringCluster: { type: Boolean, default: true },
     projectIgnoringClusterSize: { type: Number, default: 50, min: 1, max: 5000 },
+    preserveIgnoringOnRebase: { type: Boolean, default: false },
     createdAt: { type: Date, default: Date.now },
 });
 


### PR DESCRIPTION
Allow preserving ignoring rectangles on rebase/debase actions in a project.

This change allows us to add new screenshots and rebase without having to re-add ignoring rectangles to pre-existing and already approved screenshots.