### PR TITLE
feat(Deployment): Add Ready-to-go (r2g) docker compose and Dockerfiles

### DIFF
--- a/env/docker-compose.r2g.yaml
+++ b/env/docker-compose.r2g.yaml
@@ -1,0 +1,64 @@
+version: "3.7"
+services:
+
+  micoo-nginx:
+    image: mattastach/micoo-nginx:latest
+    container_name: micoo-nginx
+    ports:
+      - "8123:80"
+    networks:
+      - nginx-network
+    volumes:
+      - "exchange-volume:/exchange"
+    depends_on:
+      - micoo-dashboard
+      - micoo-engine
+
+  micoo-mongodb:
+    image: mattastach/micoo-mongodb:latest
+    container_name: micoo-mongodb
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=mgadmin
+      - MONGO_INITDB_ROOT_PASSWORD=Password1
+      - MONGO_INITDB_DATABASE=micoo
+    networks:
+      - micoo-network
+    volumes:
+      - "database-volume:/data/db"
+
+  micoo-dashboard:
+    image: ariman/micoo-dashboard:latest
+    container_name: micoo-dashboard
+    environment:
+      - MICOO_ENV=docker
+      - MICOO_FS_HOST_URL=http://localhost:8123
+      - MICOO_DB_USERNAME=micoo-user
+      - MICOO_DB_PASSWORD=micoo-password
+    volumes:
+      - "exchange-volume:/exchange"
+    networks:
+      - micoo-network
+      - nginx-network
+
+  micoo-engine:
+    image: ariman/micoo-engine:latest
+    container_name: micoo-engine
+    environment:
+      - MICOO_ENV=docker
+      - MICOO_FS_HOST_URL=http://localhost:8123
+      - MICOO_DB_USERNAME=micoo-user
+      - MICOO_DB_PASSWORD=micoo-password
+      - MICOO_COMP_MEM_LIMIT=500
+    volumes:
+      - "exchange-volume:/exchange"
+    networks:
+      - micoo-network
+      - nginx-network
+
+volumes:
+  database-volume:
+  exchange-volume:
+
+networks:
+  micoo-network:
+  nginx-network:

--- a/env/mongo/Dockerfile
+++ b/env/mongo/Dockerfile
@@ -1,0 +1,3 @@
+FROM mongo:4
+
+COPY ./initializer/mongo-init.js /docker-entrypoint-initdb.d/mongo.init.js

--- a/env/mongo/initializer/mongo-init.js
+++ b/env/mongo/initializer/mongo-init.js
@@ -1,0 +1,10 @@
+db.createUser({
+    user: "micoo-user",
+    pwd: "micoo-password",
+    roles: [
+        {
+            role: "readWrite",
+            db: "micoo",
+        },
+    ],
+});

--- a/env/nginx/containerize/Dockerfile.r2g
+++ b/env/nginx/containerize/Dockerfile.r2g
@@ -1,0 +1,11 @@
+FROM nginx
+
+RUN mkdir /initializer
+
+COPY initializer/initializer.sh /initializer/initializer.sh
+
+COPY ../nginx.reverse-proxy.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+ENTRYPOINT ["bash", "/initializer/initializer.sh"]

--- a/env/nginx/containerize/build-ready2go-image.sh
+++ b/env/nginx/containerize/build-ready2go-image.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker build --rm -f ./Dockerfile.r2g --tag=micoo-nginx:dev .

--- a/env/nginx/containerize/nginx.reverse-proxy.conf
+++ b/env/nginx/containerize/nginx.reverse-proxy.conf
@@ -1,0 +1,54 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    client_max_body_size 10M;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    autoindex       on;
+
+    server {
+        listen          80;
+        server_name     dashboard.micoo engine.micoo micoo localhost;
+
+        location / {
+            proxy_pass http://micoo-dashboard:3001/;
+            proxy_set_header    Host $host;
+            proxy_set_header    X-Real-IP $remote_addr;
+            proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header    X-Forwarded-Proto $scheme;
+        }
+
+        location /engine/ {
+            proxy_pass http://micoo-engine:3002/;
+        }
+
+        location /file-server/ {
+            root /exchange;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Love the project and have just started using it for regular regression tests, however there was a bit of trouble involved when setting it up to be hosted within Azure, so I thought I'd propose some changes to fix that.

This PR creates the changes for a "ready-to-go" version of Micoo which can be deployed to PaaS systems (Azure App Service for example), so that the user does not have to access the file system to place the Nginx config file and Mongo initialiser script.

Mongo container:
- Add a custom image
- Include init script in the image

Nginx container:
- Include reverse proxy in image

Docker compose:
- Add ready-to-go ("r2g") version, which can be used as an immediate drop-in docker compose file without access to any of the underlying OS.